### PR TITLE
zephyr: Transform into Zephyr module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+if(CONFIG_COBS)
+
+zephyr_interface_library_named(COBS)
+target_include_directories(COBS INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+zephyr_library()
+zephyr_library_sources(
+    cobs.c
+)
+
+zephyr_library_link_libraries(COBS)
+target_link_libraries(COBS INTERFACE zephyr_interface)
+
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,8 @@
+mainmenu "Consistent Overhead Byte Stuffing"
+
+menu "COBS"
+
+    config COBS
+    bool "Enable COBS library"
+
+endmenu

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+build:
+  cmake: .
+  kconfig: Kconfig
+


### PR DESCRIPTION
Add zephyr/module.yml, CMakeLists.txt and Kconfig files so that the code can be managed by west and used in Zephyr OS based projects.