### PR TITLE
Kconfig: Remove mainmenu setting

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,5 +1,3 @@
-mainmenu "Consistent Overhead Byte Stuffing"
-
 menu "COBS"
 
     config COBS


### PR DESCRIPTION
Setting the mainmenu overrides the mainmenu
setting in any project that imports cobs.